### PR TITLE
add configuration file + generate query + display result of query

### DIFF
--- a/venv/configuration.py
+++ b/venv/configuration.py
@@ -1,0 +1,30 @@
+stemming = False
+default = True
+default_row_data_path = r'F:\laela\Desktop\latimes\latimes'
+default_json_path = r'.\resources'
+
+
+def get_row_data_path():
+    """
+    :return: A string which is the path to the row data files.
+    """
+    if default:
+        print("We are treating the data from " + default_row_data_path)
+        return default_row_data_path
+    else:
+        row_data_path = input("Please write the path to the folder that contains the data.\n")
+        print("We are treating the data from " + row_data_path)
+        return row_data_path
+
+
+def get_json_path():
+    """
+    :return: A string which is the path to the json files.
+    """
+    if default:
+        print("We are treating the data from " + default_json_path)
+        return default_json_path
+    else:
+        json_path = input("Please write the path to the folder that contains the json files.\n")
+        print("We are treating the data from " + json_path)
+        return json_path


### PR DESCRIPTION
This commit should allow to : 
- have a config file --> you can choose to apply stemming or not + you can define default paths to important folders.
- Files "readchg.txt" and "readmela" can now go back to their original folder (the folder "latimes" where there are data files).
- In addition to the two json files "dict_with_dict.json" and "dict_with_list.json", there is another json file named "corpus_by_doc_id.json" (which should be generated through dataReading.py). It is a dictionnary where the key is the doc id and the value is a string representing the content of this doc. It looks like the simplest solution to get the content of a doc by the doc_id, but let me know if you think otherwise.
- you can now generate random queries or the user can specify a query. the user can choose to display  the contents of the docs.